### PR TITLE
Tighten the hash parameter to match the upstream epp function

### DIFF
--- a/lib/puppet/functions/multi_epp.rb
+++ b/lib/puppet/functions/multi_epp.rb
@@ -6,7 +6,7 @@ Puppet::Functions.create_function(:multi_epp, Puppet::Functions::InternalFunctio
   dispatch :epp_templates do
     scope_param
     param 'Array[String]', :templates
-    optional_param 'Hash', :params
+    optional_param 'Hash[Pattern[/^\w+$/], Any]', :parameters
   end
 
 


### PR DESCRIPTION
There is no reason to be more permissive than the internal
function we call so change the Hash param to match epp itself.
https://github.com/puppetlabs/puppet/blob/9d271069ba60500abfa62b92b4b81df6ecd12aab/lib/puppet/functions/epp.rb#L39